### PR TITLE
Switch to using a local filename and hash for updating lambdas

### DIFF
--- a/function/main.tf
+++ b/function/main.tf
@@ -5,6 +5,7 @@ resource "aws_lambda_function" "lambda_function" {
   role                           = "${var.execution_role_arn}"
   runtime                        = "${var.runtime}"
   filename                       = "${var.filename}"
+  source_code_hash               = "${var.source_code_hash}"
   timeout                        = "${var.timeout}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 

--- a/function/main.tf
+++ b/function/main.tf
@@ -4,8 +4,7 @@ resource "aws_lambda_function" "lambda_function" {
   memory_size                    = "${var.memory_size}"
   role                           = "${var.execution_role_arn}"
   runtime                        = "${var.runtime}"
-  s3_bucket                      = "${var.s3_bucket}"
-  s3_key                         = "${var.function_name}-${var.environment}/lambda.zip"
+  filename                       = "${var.filename}"
   timeout                        = "${var.timeout}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 

--- a/function/variables.tf
+++ b/function/variables.tf
@@ -3,7 +3,7 @@ variable "execution_role_arn" {}
 variable "function_name" {}
 variable "handler" {}
 variable "runtime" {}
-variable "s3_bucket" {}
+variable "filename" {}
 variable "timeout" {}
 
 variable subnet_ids {

--- a/function/variables.tf
+++ b/function/variables.tf
@@ -4,6 +4,9 @@ variable "function_name" {}
 variable "handler" {}
 variable "runtime" {}
 variable "filename" {}
+
+variable "source_code_hash" {}
+
 variable "timeout" {}
 
 variable subnet_ids {


### PR DESCRIPTION
This uses the `filename` and `source_code_hash` values to detect changes in the lambda code so that PRs to terraform-aws can be used to update production lambda code.